### PR TITLE
Simplify home page

### DIFF
--- a/templates/main/home.html
+++ b/templates/main/home.html
@@ -11,7 +11,7 @@
 
 			<h1><a href="/">WatCamp</a></h1>
 			<h2>Tech events in Waterloo region. </h2>
-			<p>This page lists events in Waterloo Region coming up in the next week. View the <a href="#calendar">full calendar</a> to see more events. Anyone can contribute to this calendar <a href="#contribute">click here</a> to learn how.<p>
+			<p>View the <a href="#calendar">full calendar</a> to see upcoming tech events in Waterloo region. Anyone can contribute to this calendar <a href="#contribute">click here</a> to learn how.<p>
 		</div>
 	</div>
 

--- a/templates/main/home.html
+++ b/templates/main/home.html
@@ -11,7 +11,7 @@
 
 			<h1><a href="/">WatCamp</a></h1>
 			<h2>Tech events in Waterloo region. </h2>
-			<p>View the <a href="#calendar">full calendar</a> to see upcoming tech events in Waterloo region. Anyone can contribute to this calendar <a href="#contribute">click here</a> to learn how.<p>
+			<p>View the <a href="#calendar">full calendar</a> to see upcoming tech events in Waterloo region. Anyone can contribute to this calendar; <a href="#contribute">click here</a> to learn how.<p>
 		</div>
 	</div>
 


### PR DESCRIPTION
The front page does not list this week's events any more, so remove wording that suggests this. Also fix a grammar thing.