### PR TITLE
Embed gcal responsively without Javascript

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -23,3 +23,27 @@ div{
 .navbar .nav{
 	width: 100%;
 }
+
+/* Embed Google calendar responsively.
+ * See: embedresponsively.com
+ */
+.embed-container {
+    position: relative;
+    padding-bottom: 5%;
+    overflow: hidden;
+    max-width: 100%;
+
+    /* This should probably be rex, but that
+     * does not exist. It is not clear whether
+     * rem or em is more appropriate.
+     */
+    height: 70em;
+}
+
+.embed-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -63,7 +63,10 @@
    <div id="bodyArea">
     <p>Comumunity curated calendar of tech events in Waterloo Region</p>
     <p>The full site requires JavaScript to be enabled</p>
-  <iframe src="https://www.google.com/calendar/b/0/htmlembed?height=600&wkst=1&bgcolor=%23FFFFFF&src=nlkc39jt4p0nbc4pk9pj7p5fh0@group.calendar.google.com&color=%23A32929&ctz=America/New_York&gsessionid=OK" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
+    <div class="embed-container">
+
+      <iframe src="https://www.google.com/calendar/b/0/htmlembed?height=600&wkst=1&bgcolor=%23FFFFFF&src=nlkc39jt4p0nbc4pk9pj7p5fh0@group.calendar.google.com&color=%23A32929&ctz=America/New_York&gsessionid=OK" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
 
    </div>
 

--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
 
 
    <div id="bodyArea">
-    <p>Comumunity curated calendar of tech events in Waterloo Region</p>
-    <p>The full site requires JavaScript to be enabled</p>
+    <p>Comumunity curated calendar of tech events in Waterloo Region.</p>
+    <p>The full site requires JavaScript to be enabled.</p>
     <div class="embed-container">
 
       <iframe src="https://www.google.com/calendar/b/0/htmlembed?height=600&wkst=1&bgcolor=%23FFFFFF&src=nlkc39jt4p0nbc4pk9pj7p5fh0@group.calendar.google.com&color=%23A32929&ctz=America/New_York&gsessionid=OK" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
When Javascript is disabled an HTML-only version of the calendar is displayed. That is good, but the calendar is not embedded responsively, and often looks cut-off. This uses concepts from http://embedresponsively.com to embed the calendar responsively using CSS. This is still a hack (I had to set a height manually) but the calendar works much better now.