### PR TITLE
Camelcase embeds

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -27,7 +27,7 @@ div{
 /* Embed Google calendar responsively.
  * See: embedresponsively.com
  */
-.embed-container {
+.embedContainer {
     position: relative;
     padding-bottom: 5%;
     overflow: hidden;
@@ -40,7 +40,7 @@ div{
     height: 70em;
 }
 
-.embed-container iframe {
+.embedContainer iframe {
     position: absolute;
     top: 0;
     left: 0;

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
    <div id="bodyArea">
     <p>Comumunity curated calendar of tech events in Waterloo Region.</p>
     <p>The full site requires JavaScript to be enabled.</p>
-    <div class="embed-container">
+    <div class="embedContainer">
 
       <iframe src="https://www.google.com/calendar/b/0/htmlembed?height=600&wkst=1&bgcolor=%23FFFFFF&src=nlkc39jt4p0nbc4pk9pj7p5fh0@group.calendar.google.com&color=%23A32929&ctz=America/New_York&gsessionid=OK" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
     </div>

--- a/templates/main/calendar.html
+++ b/templates/main/calendar.html
@@ -1,7 +1,7 @@
 <h1>Events Calendar</h1>
 
 <div class="row">
-	<div class="span12">
+	<div class="span12 embed-container">
 		<iframe src="http://www.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=nlkc39jt4p0nbc4pk9pj7p5fh0%40group.calendar.google.com&amp;color=%23A32929&amp;ctz=America%2FNew_York" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
 	</div>
 </div>

--- a/templates/main/calendar.html
+++ b/templates/main/calendar.html
@@ -1,7 +1,7 @@
 <h1>Events Calendar</h1>
 
 <div class="row">
-	<div class="span12 embed-container">
+	<div class="span12 embedContainer">
 		<iframe src="http://www.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=nlkc39jt4p0nbc4pk9pj7p5fh0%40group.calendar.google.com&amp;color=%23A32929&amp;ctz=America%2FNew_York" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
 	</div>
 </div>


### PR DESCRIPTION
This is not a completely clean pull request, but it is pretty small, so I hope it is okay.

It does two things: 
- turn the embed CSS classes into camel case
- Make the js-enabled calendar page embed responsively too (before it was only the javascript-free page that had this enabled).