### PR TITLE
Restore calendar to no-Javascript front page view

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,15 @@
     <p>The full site requires JavaScript to be enabled.</p>
 
     <div class="row">
+      <div class="span12 embedContainer">
+               
+         <iframe src="https://www.google.com/calendar/b/0/htmlembed?height=600&wkst=1&bgcolor=%23FFFFFF&src=nlkc39jt4p0nbc4pk9pj7p5fh0@group.calendar.google.com&color=%23A32929&ctz=America/New_York&gsessionid=OK" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
+
+      </div>
+    </div>
+
+
+    <div class="row">
     	<div class="span12">
     	<a href="http://www.google.com/calendar/ical/nlkc39jt4p0nbc4pk9pj7p5fh0%40group.calendar.google.com/public/basic.ics"><img src="http://www.google.com/calendar/images/ical.gif"/></a> <a target="_blank" href="http://www.google.com/calendar/embed?src=nlkc39jt4p0nbc4pk9pj7p5fh0%40group.calendar.google.com&amp;ctz=America/New_York"><img src="http://www.google.com/calendar/images/html.gif"/></a>
     </div>


### PR DESCRIPTION
This copies the html-only calendar code to the frontpage, so that browsers without Javascript can see calendar results. It does not undo @spaetzel 's changes to make the calendar appear on the front page, however.