### PR TITLE
Enable bootstrap library (fixes #11)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,8 @@ define([
   'underscore',
   'backbone',
   'router', // Request router.js
-], function($, _, Backbone, Router){
+  'bootstrap',
+], function($, _, Backbone, Router, Bootstrap){
   var initialize = function(){
     // Pass in our Router module and call it's initialize function
     Router.initialize();


### PR DESCRIPTION
This patch enables the Bootstrap library in the code. This fixes #11 without creating a custom listener. That way we don't have to worry about where the custom listener gets called. 