### PR TITLE
Add link to WatCamp newsletter mailing list

### DIFF
--- a/templates/main/home.html
+++ b/templates/main/home.html
@@ -11,7 +11,9 @@
 
 			<h1><a href="/">WatCamp</a></h1>
 			<h2>Tech events in Waterloo region. </h2>
-			<p>View the <a href="#calendar">full calendar</a> to see upcoming tech events in Waterloo region. Anyone can contribute to this calendar; <a href="#contribute">click here</a> to learn how.<p>
+			<p>View the <a href="#calendar">full calendar</a> to see upcoming tech events in Waterloo region.</p>
+            <p>To receive event listings in a weekly email, subscribe to the <a href="https://off-topic.kwlug.org/mailman/listinfo/watcamp-newsletter_off-topic.kwlug.org">WatCamp newsletter</a>.</p>
+            <p>Anyone can contribute to this calendar; <a href="#contribute">click here</a> to learn how.<p>
 		</div>
 	</div>
 


### PR DESCRIPTION
There has been an email list version of WatCamp running for about a year now[1]. About 30 people receive it and many of them find it useful. I would like to tie this newsletter more closely to the official WatCamp website by putting a link to the newsletter signup on the front page.

I am hoping that the wording is okay, and that the new link is not too obtrusive. I think it fits in okay. Are you willing to incorporate it?

[1] The existing list looks new because I just switched the domain for the mailing list recently, and the easiest way to do that was to recreate the list from scratch and migrate all the subscribers. 